### PR TITLE
BUGFIX: Update e_rem_pio2.c

### DIFF
--- a/libm/e_exp.c
+++ b/libm/e_exp.c
@@ -143,7 +143,7 @@ double __ieee754_exp(double x)	/* default IEEE double exp */
 	c  = x - t*(P1+t*(P2+t*(P3+t*(P4+t*P5))));
 	if(k==0) 	return one-((x*c)/(c-2.0)-x);
 	else 		y = one-((lo-(x*c)/(2.0-c))-hi);
-	if(k >= -1021) {
+	if(k >= 0) {
 	    u_int32_t hy;
 	    GET_HIGH_WORD(hy,y);
 	    SET_HIGH_WORD(y,hy+(k<<20));	/* add k to y's exponent */

--- a/libm/e_rem_pio2.c
+++ b/libm/e_rem_pio2.c
@@ -146,7 +146,7 @@ int32_t __ieee754_rem_pio2(double x, double *y)
     /* set z = scalbn(|x|,ilogb(x)-23) */
 	GET_LOW_WORD(low,x);
 	SET_LOW_WORD(z,low);
-	e0 	= (ix>>20)-1046;	/* e0 = ilogb(z)-23; */
+	e0 	= (ix>>20)-1043;	/* e0 = ilogb(z)-23; */
 	SET_HIGH_WORD(z, ix - ((int32_t)(e0<<20)));
 	for(i=0;i<2;i++) {
 		tx[i] = (double)((int32_t)(z));


### PR DESCRIPTION
`e0` is being shifted left, but the minimal possible value it may assume according to checks and operations above is `-3`. Shifting negative value to the left is UB in C. Most likely, here `1043` should be subtracted instead of `1046`.